### PR TITLE
Use travis ci cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 bundler_args: "--jobs=3 --retry=3 --without development --without production --deployment"
 language: ruby
 rvm:
@@ -17,3 +18,6 @@ before_install:
 script:
 - bundle exec rake db:create db:test:load spec
 - bundle exec rubocop
+cache:
+  directories:
+  - vendor/bundle


### PR DESCRIPTION
Travic-ci cache is now enabled:
http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade
